### PR TITLE
Create sony-camera-backdoor.yaml

### DIFF
--- a/iot/sony-camera-backdoor.yaml
+++ b/iot/sony-camera-backdoor.yaml
@@ -1,0 +1,42 @@
+id: sony-camera-backdoor
+
+info:
+  name: Backdoor In Sony IPELA Engine IP Cameras
+  author: af001
+  severity: medium
+  reference: 
+    - https://sec-consult.com/vulnerability-lab/advisory/backdoor-vulnerability-in-sony-ipela-engine-ip-cameras/
+    - https://www.bleepingcomputer.com/news/security/backdoor-found-in-80-sony-surveillance-camera-models/
+    - https://jvn.jp/en/vu/JVNVU96435227/index.html
+  remediation: Upgrade to the latest version of the firmware provided by Sony.
+  tags: sony,backdoor,unauth,telnet
+  classification:
+    cvss-metrics: CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N/E:P/RL:O/RC:C
+    cvss-score: 6.50
+    cve-id: CVE-2016-7834
+    cwe-id: CWE-798
+  description: "Multiple SONY network cameras vulnerable to sensitive information disclosure via hardcoded credentials and a backdoor."
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/command/prima-factory.cgi"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 401
+
+      - type: word
+        part: header
+        words:
+          - 'gen5th'
+          - 'gen6th'
+        condition: or
+
+      - type: word
+        part: header
+        words:
+          - 'Sony'
+        condition: and


### PR DESCRIPTION
Sony backdoor check in some IP cameras.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Add CVE-2016-7834
- References:
- https://jvn.jp/en/vu/JVNVU96435227/index.html
- https://sec-consult.com/vulnerability-lab/advisory/backdoor-vulnerability-in-sony-ipela-engine-ip-cameras/
- https://www.bleepingcomputer.com/news/security/backdoor-found-in-80-sony-surveillance-camera-models/
### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->

<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
[2022-04-11 09:56:16] [sony-camera-backdoor] [http] [medium] http://172.16.0.2/command/prima-factory.cgi
[2022-04-11 09:56:16] [sony-camera-backdoor] [http] [medium] http://172.16.0.5/command/prima-factory.cgi
[2022-04-11 09:56:16] [sony-camera-backdoor] [http] [medium] http://172.16.0.101/command/prima-factory.cgi

There is basic auth implemented on the vulnerable endpoint. The hardcoded credential is primana: primana. Without the basic auth, the server will always respond with a 401 status code, and a 'Server' header is added in the response that contains 'gen5th' or 'gen6th'. There also a string in the header containing the word 'Sony'. I have another template that auto-enables the Telnet backdoor, but I'll keep that in my local repo. 

<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)